### PR TITLE
feat: task to refresh xblock skills

### DIFF
--- a/taxonomy/choices.py
+++ b/taxonomy/choices.py
@@ -22,5 +22,5 @@ class ProductTypes(DjangoChoices):
 
     Course = ChoiceItem('course', 'Course')
     Program = ChoiceItem('program', 'Program')
-    Xblock = ChoiceItem('xblock', 'Xblock')
-    XblockThrough = ChoiceItem('xblock_through', 'XblockThrough')
+    XBlock = ChoiceItem('xblock', 'XBlock')
+    XBlockThrough = ChoiceItem('xblock_through', 'XBlockThrough')

--- a/taxonomy/choices.py
+++ b/taxonomy/choices.py
@@ -22,3 +22,5 @@ class ProductTypes(DjangoChoices):
 
     Course = ChoiceItem('course', 'Course')
     Program = ChoiceItem('program', 'Program')
+    Xblock = ChoiceItem('xblock', 'Xblock')
+    XblockThrough = ChoiceItem('xblock_through', 'XblockThrough')

--- a/taxonomy/choices.py
+++ b/taxonomy/choices.py
@@ -23,4 +23,4 @@ class ProductTypes(DjangoChoices):
     Course = ChoiceItem('course', 'Course')
     Program = ChoiceItem('program', 'Program')
     XBlock = ChoiceItem('xblock', 'XBlock')
-    XBlockThrough = ChoiceItem('xblock_through', 'XBlockThrough')
+    XBlockData = ChoiceItem('xblock_data', 'XBlockData')

--- a/taxonomy/providers/__init__.py
+++ b/taxonomy/providers/__init__.py
@@ -5,4 +5,4 @@ Expose the abstract providers.
 
 from taxonomy.providers.course_metadata import CourseMetadataProvider
 from taxonomy.providers.program_metadata import ProgramMetadataProvider
-from taxonomy.providers.xblock_metadata import XBlockMetadataProvider
+from taxonomy.providers.xblock_metadata import XBlockContent, XBlockMetadataProvider

--- a/taxonomy/providers/__init__.py
+++ b/taxonomy/providers/__init__.py
@@ -5,3 +5,4 @@ Expose the abstract providers.
 
 from taxonomy.providers.course_metadata import CourseMetadataProvider
 from taxonomy.providers.program_metadata import ProgramMetadataProvider
+from taxonomy.providers.xblock_metadata import XblockMetadataProvider

--- a/taxonomy/providers/__init__.py
+++ b/taxonomy/providers/__init__.py
@@ -5,4 +5,4 @@ Expose the abstract providers.
 
 from taxonomy.providers.course_metadata import CourseMetadataProvider
 from taxonomy.providers.program_metadata import ProgramMetadataProvider
-from taxonomy.providers.xblock_metadata import XblockMetadataProvider
+from taxonomy.providers.xblock_metadata import XBlockMetadataProvider

--- a/taxonomy/providers/utils.py
+++ b/taxonomy/providers/utils.py
@@ -30,3 +30,13 @@ def get_program_metadata_provider(*args, **kwargs):
     the `*args` and `**kwargs` provided in the function arguments and return the instance.
     """
     return import_string(settings.TAXONOMY_PROGRAM_METADATA_PROVIDER)(*args, **kwargs)
+
+
+def get_xblock_metadata_provider(*args, **kwargs):
+    """
+    Load and return an instance of xblock metadata provider.
+
+    Load xblock metadata provider class through `TAXONOMY_XBOCK_METADATA_PROVIDER`, instantiate it using
+    the `*args` and `**kwargs` provided in the function arguments and return the instance.
+    """
+    return import_string(settings.TAXONOMY_XBOCK_METADATA_PROVIDER)(*args, **kwargs)

--- a/taxonomy/providers/utils.py
+++ b/taxonomy/providers/utils.py
@@ -36,7 +36,7 @@ def get_xblock_metadata_provider(*args, **kwargs):
     """
     Load and return an instance of xblock metadata provider.
 
-    Load xblock metadata provider class through `TAXONOMY_XBOCK_METADATA_PROVIDER`, instantiate it using
+    Load xblock metadata provider class through `TAXONOMY_XBLOCK_METADATA_PROVIDER`, instantiate it using
     the `*args` and `**kwargs` provided in the function arguments and return the instance.
     """
-    return import_string(settings.TAXONOMY_XBOCK_METADATA_PROVIDER)(*args, **kwargs)
+    return import_string(settings.TAXONOMY_XBLOCK_METADATA_PROVIDER)(*args, **kwargs)

--- a/taxonomy/providers/xblock_metadata.py
+++ b/taxonomy/providers/xblock_metadata.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+"""
+Abstract base class for xblock metadata providers.
+
+All host platform must implement this provider in order for taxonomy to work.
+"""
+from abc import abstractmethod
+
+
+class XblockMetadataProvider:
+    """
+    Abstract base class for xblock metadata providers.
+
+    All abstract methods must be implemented for taxonomy's normal functionality.
+    """
+
+    @abstractmethod
+    def get_xblocks(self, xblock_ids):
+        """
+        Get a list of xblocks matching the xblock ids provided in the argument.
+        Include content of all children xblocks in content
+
+        Arguments:
+          xblock_ids(list<str>): A list of UUIDs in the form of a string.
+
+        Returns:
+          list<dict>: A list of xblocks in the form of dictionary.
+            Dictionary object must have the following keys
+            1. key: xblock usage key
+            2. content_type: xblock content type
+            3. content: xblock text content
+        """
+
+    @abstractmethod
+    def get_all_xblocks(self):
+        """
+        Get iterator for all the xblocks.
+
+        Returns:
+          iterator<dict>: An iterator of xblocks in the form of dictionary.
+            Dictionary object must have the following keys
+            1. key: xblock usage key
+            2. content_type: xblock content type
+            3. content: xblock text content
+        """

--- a/taxonomy/providers/xblock_metadata.py
+++ b/taxonomy/providers/xblock_metadata.py
@@ -7,7 +7,7 @@ All host platform must implement this provider in order for taxonomy to work.
 from abc import abstractmethod
 
 
-class XblockMetadataProvider:
+class XBlockMetadataProvider:
     """
     Abstract base class for xblock metadata providers.
 

--- a/taxonomy/providers/xblock_metadata.py
+++ b/taxonomy/providers/xblock_metadata.py
@@ -5,6 +5,11 @@ Abstract base class for xblock metadata providers.
 All host platform must implement this provider in order for taxonomy to work.
 """
 from abc import abstractmethod
+from collections import namedtuple
+from typing import Iterator, List
+
+
+XBlockContent = namedtuple("XBlockContent", ["key", "content_type", "content"])
 
 
 class XBlockMetadataProvider:
@@ -15,7 +20,7 @@ class XBlockMetadataProvider:
     """
 
     @abstractmethod
-    def get_xblocks(self, xblock_ids: list):
+    def get_xblocks(self, xblock_ids: list) -> List[XBlockContent]:
         """
         Get a list of xblocks matching the xblock ids provided in the argument.
         Include content of all children xblocks in content
@@ -24,21 +29,21 @@ class XBlockMetadataProvider:
           xblock_ids(list<str>): A list of UUIDs in the form of a string.
 
         Returns:
-          list<dict>: A list of xblocks dictionary.
-            Dictionary object must have the following keys
+          list<XBlockContent>: A list of XBlockContent objects.
+            XBlockContent object must have the following keys
             1. key: xblock usage key
             2. content_type: xblock content type
             3. content: xblock text content
         """
 
     @abstractmethod
-    def get_all_xblocks_in_course(self, course_id: str):
+    def get_all_xblocks_in_course(self, course_id: str) -> Iterator[XBlockContent]:
         """
         Get iterator for all the unit/video xblocks in course.
 
         Returns:
-          iterator<dict>: An iterator of xblocks dictionary.
-            Dictionary object must have the following keys
+          iterator<XBlockContent>: An iterator of xblocks dictionary.
+            XBlockContent object must have the following keys
             1. key: xblock usage key
             2. content_type: xblock content type
             3. content: xblock text content

--- a/taxonomy/providers/xblock_metadata.py
+++ b/taxonomy/providers/xblock_metadata.py
@@ -24,7 +24,7 @@ class XBlockMetadataProvider:
           xblock_ids(list<str>): A list of UUIDs in the form of a string.
 
         Returns:
-          list<dict>: A list of xblocks in the form of dictionary.
+          list<dict>: A list of xblocks dictionary.
             Dictionary object must have the following keys
             1. key: xblock usage key
             2. content_type: xblock content type
@@ -37,7 +37,7 @@ class XBlockMetadataProvider:
         Get iterator for all the unit/video xblocks in course.
 
         Returns:
-          iterator<dict>: An iterator of xblocks in the form of dictionary.
+          iterator<dict>: An iterator of xblocks dictionary.
             Dictionary object must have the following keys
             1. key: xblock usage key
             2. content_type: xblock content type

--- a/taxonomy/providers/xblock_metadata.py
+++ b/taxonomy/providers/xblock_metadata.py
@@ -15,7 +15,7 @@ class XBlockMetadataProvider:
     """
 
     @abstractmethod
-    def get_xblocks(self, xblock_ids):
+    def get_xblocks(self, xblock_ids: list):
         """
         Get a list of xblocks matching the xblock ids provided in the argument.
         Include content of all children xblocks in content
@@ -32,9 +32,9 @@ class XBlockMetadataProvider:
         """
 
     @abstractmethod
-    def get_all_xblocks(self):
+    def get_all_xblocks_in_course(self, course_id: str):
         """
-        Get iterator for all the xblocks.
+        Get iterator for all the unit/video xblocks in course.
 
         Returns:
           iterator<dict>: An iterator of xblocks in the form of dictionary.

--- a/taxonomy/signals/handlers.py
+++ b/taxonomy/signals/handlers.py
@@ -6,9 +6,9 @@ import logging
 
 from django.dispatch import receiver
 
-from taxonomy.tasks import update_course_skills, update_program_skills
+from taxonomy.tasks import update_course_skills, update_program_skills, update_xblock_skills
 
-from .signals import UPDATE_COURSE_SKILLS, UPDATE_PROGRAM_SKILLS
+from .signals import UPDATE_COURSE_SKILLS, UPDATE_PROGRAM_SKILLS, UPDATE_XBLOCK_SKILLS
 
 LOGGER = logging.getLogger(__name__)
 
@@ -29,3 +29,12 @@ def handle_update_program_skills(sender, program_uuid, **kwargs):  # pylint: dis
     """
     LOGGER.info('[TAXONOMY] UPDATE_PROGRAM_SKILLS signal received')
     update_program_skills.delay([program_uuid])
+
+
+@receiver(UPDATE_XBLOCK_SKILLS)
+def handle_update_xblock_skills(sender, xblock_uuid, **kwargs):  # pylint: disable=unused-argument
+    """
+    Handle signal and trigger task to update xblock skills.
+    """
+    LOGGER.info('[TAXONOMY] UPDATE_XBLOCK_SKILLS signal received')
+    update_xblock_skills.delay([xblock_uuid])

--- a/taxonomy/signals/signals.py
+++ b/taxonomy/signals/signals.py
@@ -7,3 +7,4 @@ from django.dispatch import Signal
 
 UPDATE_COURSE_SKILLS = Signal()
 UPDATE_PROGRAM_SKILLS = Signal()
+UPDATE_XBLOCK_SKILLS = Signal()

--- a/taxonomy/tasks.py
+++ b/taxonomy/tasks.py
@@ -9,7 +9,11 @@ from celery import shared_task
 
 from taxonomy import utils
 from taxonomy.choices import ProductTypes
-from taxonomy.providers.utils import get_course_metadata_provider, get_program_metadata_provider
+from taxonomy.providers.utils import (
+    get_course_metadata_provider,
+    get_program_metadata_provider,
+    get_xblock_metadata_provider
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -44,3 +48,19 @@ def update_program_skills(program_uuids):
         utils.refresh_product_skills(programs, True, ProductTypes.Program)
     else:
         LOGGER.warning('[TAXONOMY] No program found with uuids [%d] to update skills.', program_uuids)
+
+
+@shared_task()
+def update_xblock_skills(xblock_uuids):
+    """
+    Task to update xblock skills.
+
+    Arguments:
+        xblock_uuids (list): uuids of xblocks for which skills needs to be updated
+    """
+    LOGGER.info('[TAXONOMY] refresh_xblock_skills task triggered')
+    xblocks = get_xblock_metadata_provider().get_xblocks(xblock_ids=xblock_uuids)
+    if xblocks:
+        utils.refresh_product_skills(xblocks, True, ProductTypes.Xblock)
+    else:
+        LOGGER.warning('[TAXONOMY] No xblock found with uuids [%d] to update skills.', xblock_uuids)

--- a/taxonomy/tasks.py
+++ b/taxonomy/tasks.py
@@ -61,6 +61,6 @@ def update_xblock_skills(xblock_uuids):
     LOGGER.info('[TAXONOMY] refresh_xblock_skills task triggered')
     xblocks = get_xblock_metadata_provider().get_xblocks(xblock_ids=xblock_uuids)
     if xblocks:
-        utils.refresh_product_skills(xblocks, True, ProductTypes.Xblock)
+        utils.refresh_product_skills(xblocks, True, ProductTypes.XBlock)
     else:
         LOGGER.warning('[TAXONOMY] No xblock found with uuids [%d] to update skills.', xblock_uuids)

--- a/taxonomy/utils.py
+++ b/taxonomy/utils.py
@@ -19,7 +19,7 @@ from taxonomy.constants import (
 )
 from taxonomy.emsi.client import EMSISkillsApiClient
 from taxonomy.exceptions import TaxonomyAPIError
-from taxonomy.models import CourseSkills, ProgramSkill, JobSkills, Skill, Translation, XblockSkillThrough, XblockSkills
+from taxonomy.models import CourseSkills, ProgramSkill, JobSkills, Skill, Translation, XBlockSkillThrough, XBlockSkills
 from taxonomy.serializers import SkillSerializer
 
 LOGGER = logging.getLogger(__name__)
@@ -71,7 +71,7 @@ def get_product_identifier(product_type):
     identifier = None
     if product_type == ProductTypes.Program:
         identifier = 'uuid'
-    elif product_type in (ProductTypes.Course, ProductTypes.Xblock):
+    elif product_type in (ProductTypes.Course, ProductTypes.XBlock):
         identifier = 'key'
 
     return identifier
@@ -83,21 +83,21 @@ def get_product_skill_model_and_identifier(product_type):
     """
     if product_type == ProductTypes.Program:
         return (ProgramSkill, 'program_uuid')
-    if product_type == ProductTypes.Xblock:
-        return (XblockSkills, 'usage_key')
-    if product_type == ProductTypes.XblockThrough:
-        return (XblockSkillThrough, 'xblock_id')
+    if product_type == ProductTypes.XBlock:
+        return (XBlockSkills, 'usage_key')
+    if product_type == ProductTypes.XBlockThrough:
+        return (XBlockSkillThrough, 'xblock_id')
     return (CourseSkills, 'course_key')
 
 
 def update_skills_data(key_or_uuid, skill_external_id, confidence, skill_data, product_type):
     """
-    Persist the skills data in the database for Program, Course or Xblock.
+    Persist the skills data in the database for Program, Course or XBlock.
     """
     skill, _ = Skill.objects.update_or_create(external_id=skill_external_id, defaults=skill_data)
-    if product_type == ProductTypes.Xblock:
+    if product_type == ProductTypes.XBlock:
         x_model, x_identifier = get_product_skill_model_and_identifier(product_type)
-        product_type = ProductTypes.XblockThrough
+        product_type = ProductTypes.XBlockThrough
         xblock, _ = x_model.objects.get_or_create(**{x_identifier: key_or_uuid})
         key_or_uuid = xblock.id
     if is_skill_blacklisted(key_or_uuid, skill.id, product_type):
@@ -155,7 +155,7 @@ def get_translation_attr(product_type):
     """
     if product_type == ProductTypes.Program:
         return 'overview'
-    if product_type == ProductTypes.Xblock:
+    if product_type == ProductTypes.XBlock:
         return 'content'
     return COURSE_METADATA_FIELDS_COMBINED
 
@@ -189,7 +189,7 @@ def refresh_product_skills(products, should_commit_to_db, product_type):
         if skill_attr_val:
             # TODO: Skip translation for xblock text till we find better way to
             # handle huge amounts of text
-            if product_type != ProductTypes.Xblock:
+            if product_type != ProductTypes.XBlock:
                 translated_skill_attr = get_translated_skill_attribute_val(
                     product[key_or_uuid], skill_attr_val, product_type
                 )

--- a/taxonomy/utils.py
+++ b/taxonomy/utils.py
@@ -87,7 +87,7 @@ def get_product_skill_model_and_identifier(product_type):
         product_skill = (ProgramSkill, 'program_uuid')
     elif product_type == ProductTypes.XBlock:
         product_skill = (XBlockSkills, 'usage_key')
-    elif product_type == ProductTypes.XBlockThrough:
+    elif product_type == ProductTypes.XBlockData:
         product_skill = (XBlockSkillData, 'xblock_id')
     return product_skill
 
@@ -110,7 +110,7 @@ def update_skills_data(key_or_uuid, skill_external_id, confidence, skill_data, p
     skill, _ = Skill.objects.update_or_create(external_id=skill_external_id, defaults=skill_data)
     if product_type == ProductTypes.XBlock:
         x_model, x_identifier = get_product_skill_model_and_identifier(product_type)
-        product_type = ProductTypes.XBlockThrough
+        product_type = ProductTypes.XBlockData
         xblock, _ = x_model.objects.update_or_create(
             **{x_identifier: key_or_uuid},
             defaults={"hash_content": kwargs.get("hash_content"), "auto_processed": True},

--- a/taxonomy/utils.py
+++ b/taxonomy/utils.py
@@ -21,7 +21,7 @@ from taxonomy.constants import (
 )
 from taxonomy.emsi.client import EMSISkillsApiClient
 from taxonomy.exceptions import TaxonomyAPIError
-from taxonomy.models import CourseSkills, ProgramSkill, JobSkills, Skill, Translation, XBlockSkillThrough, XBlockSkills
+from taxonomy.models import CourseSkills, ProgramSkill, JobSkills, Skill, Translation, XBlockSkillData, XBlockSkills
 from taxonomy.serializers import SkillSerializer
 
 LOGGER = logging.getLogger(__name__)
@@ -88,7 +88,7 @@ def get_product_skill_model_and_identifier(product_type):
     if product_type == ProductTypes.XBlock:
         return (XBlockSkills, 'usage_key')
     if product_type == ProductTypes.XBlockThrough:
-        return (XBlockSkillThrough, 'xblock_id')
+        return (XBlockSkillData, 'xblock_id')
     return (CourseSkills, 'course_key')
 
 

--- a/taxonomy/validators/__init__.py
+++ b/taxonomy/validators/__init__.py
@@ -5,3 +5,4 @@ Expose all the validators.
 
 from taxonomy.validators.course_metadata import CourseMetadataProviderValidator
 from taxonomy.validators.program_metadata import ProgramMetadataProviderValidator
+from taxonomy.validators.xblock_metadata import XblockMetadataProviderValidator

--- a/taxonomy/validators/__init__.py
+++ b/taxonomy/validators/__init__.py
@@ -5,4 +5,4 @@ Expose all the validators.
 
 from taxonomy.validators.course_metadata import CourseMetadataProviderValidator
 from taxonomy.validators.program_metadata import ProgramMetadataProviderValidator
-from taxonomy.validators.xblock_metadata import XblockMetadataProviderValidator
+from taxonomy.validators.xblock_metadata import XBlockMetadataProviderValidator

--- a/taxonomy/validators/xblock_metadata.py
+++ b/taxonomy/validators/xblock_metadata.py
@@ -5,6 +5,7 @@ Validator for xblock metadata provider.
 All host platform must run this validator to make sure providers are working as expected.
 """
 from taxonomy.providers.utils import get_xblock_metadata_provider
+from taxonomy.providers import XBlockContent
 
 
 class XBlockMetadataProviderValidator:
@@ -42,9 +43,7 @@ class XBlockMetadataProviderValidator:
         assert len(xblocks) == len(self.test_xblocks)
 
         for xblock in xblocks:
-            assert 'key' in xblock
-            assert 'content' in xblock
-            assert 'content_type' in xblock
+            assert isinstance(xblock, XBlockContent)
 
     def validate_get_all_xblocks_in_course(self):
         """
@@ -53,6 +52,4 @@ class XBlockMetadataProviderValidator:
         xblocks = self.xblock_metadata_provider.get_all_xblocks_in_course("dummy-course-id")
 
         for xblock in xblocks:
-            assert 'key' in xblock
-            assert 'content' in xblock
-            assert 'content_type' in xblock
+            assert isinstance(xblock, XBlockContent)

--- a/taxonomy/validators/xblock_metadata.py
+++ b/taxonomy/validators/xblock_metadata.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+"""
+Validator for xblock metadata provider.
+
+All host platform must run this validator to make sure providers are working as expected.
+"""
+from taxonomy.providers.utils import get_xblock_metadata_provider
+
+
+class XblockMetadataProviderValidator:
+    """
+    Validate that the interface requirement for xblock metadata provider matches with the implementation.
+    """
+
+    def __init__(self, test_xblocks):
+        """
+        Setup an instance of xblock metadata provider.
+
+        Since, these tests will run inside host application, list of test xblocks will also provided by the host.
+        Args:
+            test_xblocks (list<str>): List of xblock UUIDs in the form of string.
+        """
+        self.test_xblocks = test_xblocks
+        self.xblock_metadata_provider = get_xblock_metadata_provider()
+
+    def validate(self):
+        """
+        Validate XblockMetadataProvider implements the interface as expected.
+
+        Note: This is the only method that host platform will call,
+        this method is responsible for calling the rest of the validation functions.
+        """
+        self.validate_get_xblocks()
+        self.validate_get_all_xblocks()
+
+    def validate_get_xblocks(self):
+        """
+        Validate `get_xblocks` methods has the correct interface implemented.
+        """
+        xblocks = self.xblock_metadata_provider.get_xblocks(self.test_xblocks)
+
+        assert len(xblocks) == len(self.test_xblocks)
+
+        for xblock in xblocks:
+            assert 'key' in xblock
+            assert 'content' in xblock
+            assert 'content_type' in xblock
+
+    def validate_get_all_xblocks(self):
+        """
+        Validate `get_all_xblocks` methods has the correct interface implemented.
+        """
+        xblocks = self.xblock_metadata_provider.get_all_xblocks()
+
+        for xblock in xblocks:
+            assert 'key' in xblock
+            assert 'content' in xblock
+            assert 'content_type' in xblock

--- a/taxonomy/validators/xblock_metadata.py
+++ b/taxonomy/validators/xblock_metadata.py
@@ -31,7 +31,7 @@ class XBlockMetadataProviderValidator:
         this method is responsible for calling the rest of the validation functions.
         """
         self.validate_get_xblocks()
-        self.validate_get_all_xblocks()
+        self.validate_get_all_xblocks_in_course()
 
     def validate_get_xblocks(self):
         """
@@ -46,11 +46,11 @@ class XBlockMetadataProviderValidator:
             assert 'content' in xblock
             assert 'content_type' in xblock
 
-    def validate_get_all_xblocks(self):
+    def validate_get_all_xblocks_in_course(self):
         """
-        Validate `get_all_xblocks` methods has the correct interface implemented.
+        Validate `get_all_xblocks_in_course` methods has the correct interface implemented.
         """
-        xblocks = self.xblock_metadata_provider.get_all_xblocks()
+        xblocks = self.xblock_metadata_provider.get_all_xblocks_in_course("dummy-course-id")
 
         for xblock in xblocks:
             assert 'key' in xblock

--- a/taxonomy/validators/xblock_metadata.py
+++ b/taxonomy/validators/xblock_metadata.py
@@ -7,7 +7,7 @@ All host platform must run this validator to make sure providers are working as 
 from taxonomy.providers.utils import get_xblock_metadata_provider
 
 
-class XblockMetadataProviderValidator:
+class XBlockMetadataProviderValidator:
     """
     Validate that the interface requirement for xblock metadata provider matches with the implementation.
     """
@@ -25,7 +25,7 @@ class XblockMetadataProviderValidator:
 
     def validate(self):
         """
-        Validate XblockMetadataProvider implements the interface as expected.
+        Validate XBlockMetadataProvider implements the interface as expected.
 
         Note: This is the only method that host platform will call,
         this method is responsible for calling the rest of the validation functions.

--- a/test_settings.py
+++ b/test_settings.py
@@ -65,7 +65,7 @@ EMSI_CLIENT_SECRET = 'test-secret'
 
 TAXONOMY_COURSE_METADATA_PROVIDER = 'test_utils.providers.DiscoveryCourseMetadataProvider'
 TAXONOMY_PROGRAM_METADATA_PROVIDER = 'test_utils.providers.DiscoveryProgramMetadataProvider'
-TAXONOMY_XBOCK_METADATA_PROVIDER = 'test_utils.providers.DiscoveryXBlockMetadataProvider'
+TAXONOMY_XBLOCK_METADATA_PROVIDER = 'test_utils.providers.DiscoveryXBlockMetadataProvider'
 
 ### CELERY
 

--- a/test_settings.py
+++ b/test_settings.py
@@ -65,6 +65,7 @@ EMSI_CLIENT_SECRET = 'test-secret'
 
 TAXONOMY_COURSE_METADATA_PROVIDER = 'test_utils.providers.DiscoveryCourseMetadataProvider'
 TAXONOMY_PROGRAM_METADATA_PROVIDER = 'test_utils.providers.DiscoveryProgramMetadataProvider'
+TAXONOMY_XBOCK_METADATA_PROVIDER = 'test_utils.providers.DiscoveryXblockMetadataProvider'
 
 ### CELERY
 

--- a/test_settings.py
+++ b/test_settings.py
@@ -65,7 +65,7 @@ EMSI_CLIENT_SECRET = 'test-secret'
 
 TAXONOMY_COURSE_METADATA_PROVIDER = 'test_utils.providers.DiscoveryCourseMetadataProvider'
 TAXONOMY_PROGRAM_METADATA_PROVIDER = 'test_utils.providers.DiscoveryProgramMetadataProvider'
-TAXONOMY_XBOCK_METADATA_PROVIDER = 'test_utils.providers.DiscoveryXblockMetadataProvider'
+TAXONOMY_XBOCK_METADATA_PROVIDER = 'test_utils.providers.DiscoveryXBlockMetadataProvider'
 
 ### CELERY
 

--- a/test_utils/constants.py
+++ b/test_utils/constants.py
@@ -9,3 +9,4 @@ CLIENT_SECRET = 'test-secret'
 
 COURSE_KEY = 'edx+DemoX'
 PROGRAM_UUID = '118bc77a-7319-42cd-ade8-899a4e5d26ac'
+USAGE_KEY = 'block-v1:edx+DemoX+Demo_course+type@video+block@UaEBjyMjcLW65gaTXggB93WmvoxGAJa0JeHRrDThk'

--- a/test_utils/mocks.py
+++ b/test_utils/mocks.py
@@ -52,7 +52,7 @@ class MockProgram(MagicMock):
         self.overview = overview if overview is not DEFAULT else FAKER.sentence(nb_words=50)
 
 
-class MockXblock(MagicMock):
+class MockXBlock(MagicMock):
     """
     Mock object for course.
     """

--- a/test_utils/mocks.py
+++ b/test_utils/mocks.py
@@ -24,7 +24,7 @@ class MockCourse(MagicMock):
         """
         Initialize course related attributes.
         """
-        super().__init__(*args, **kwargs)
+        super().__init__(*args, spec=dict, **kwargs)
 
         self.uuid = uuid if uuid is not DEFAULT else uuid4()
         self.key = key if key is not DEFAULT else 'course-id/{}'.format(FAKER.slug())
@@ -44,7 +44,7 @@ class MockProgram(MagicMock):
         """
         Initialize program related attributes.
         """
-        super(MockProgram, self).__init__(*args, **kwargs)
+        super(MockProgram, self).__init__(*args, spec=dict, **kwargs)
 
         self.uuid = uuid if uuid is not DEFAULT else uuid4()
         self.title = title if title is not DEFAULT else 'Test Program {}'.format(FAKER.sentence())
@@ -63,8 +63,16 @@ class MockXBlock(MagicMock):
         """
         Initialize course related attributes.
         """
-        super().__init__(*args, **kwargs)
+        super().__init__(*args, spec=dict, **kwargs)
 
         self.key = key if key is not DEFAULT else 'xblock-id/{}'.format(FAKER.slug())
         self.content_type = content_type if content_type is not DEFAULT else 'Video'
         self.content = content if content is not DEFAULT else FAKER.sentence(nb_words=50)
+
+
+def mock_as_dict(mock_obj):
+    """
+    Returns a mock object which behaves like dictionary.
+    """
+    mock_obj.__getitem__.side_effect = mock_obj.__dict__.__getitem__
+    return mock_obj

--- a/test_utils/mocks.py
+++ b/test_utils/mocks.py
@@ -50,3 +50,21 @@ class MockProgram(MagicMock):
         self.title = title if title is not DEFAULT else 'Test Program {}'.format(FAKER.sentence())
         self.subtitle = subtitle if subtitle is not DEFAULT else 'Test Program Subtitle {}'.format(FAKER.sentence())
         self.overview = overview if overview is not DEFAULT else FAKER.sentence(nb_words=50)
+
+
+class MockXblock(MagicMock):
+    """
+    Mock object for course.
+    """
+    # pylint: disable=keyword-arg-before-vararg
+    def __init__(
+            self, key=DEFAULT, content_type=DEFAULT, content=DEFAULT, *args, **kwargs
+    ):
+        """
+        Initialize course related attributes.
+        """
+        super().__init__(*args, **kwargs)
+
+        self.key = key if key is not DEFAULT else 'xblock-id/{}'.format(FAKER.slug())
+        self.content_type = content_type if content_type is not DEFAULT else 'Video'
+        self.content = content if content is not DEFAULT else FAKER.sentence(nb_words=50)

--- a/test_utils/providers.py
+++ b/test_utils/providers.py
@@ -67,7 +67,7 @@ class DiscoveryProgramMetadataProvider(ProgramMetadataProvider):
         if self.mock_programs is not None:
             programs = self.mock_programs
         else:
-            programs = [MockCourse(uuid=program_id) for program_id in program_ids]
+            programs = [MockProgram(uuid=program_id) for program_id in program_ids]
 
         return [{
             'uuid': program.uuid,

--- a/test_utils/providers.py
+++ b/test_utils/providers.py
@@ -3,8 +3,8 @@
 An implementation of providers to be used in tests.
 """
 
-from taxonomy.providers import CourseMetadataProvider, ProgramMetadataProvider
-from test_utils.mocks import MockCourse, MockProgram
+from taxonomy.providers import CourseMetadataProvider, ProgramMetadataProvider, XblockMetadataProvider
+from test_utils.mocks import MockCourse, MockProgram, MockXblock
 
 
 class DiscoveryCourseMetadataProvider(CourseMetadataProvider):
@@ -90,4 +90,44 @@ class DiscoveryProgramMetadataProvider(ProgramMetadataProvider):
                 'title': program.title,
                 'subtitle': program.subtitle,
                 'overview': program.overview,
+            }
+
+
+class DiscoveryXblockMetadataProvider(XblockMetadataProvider):
+    """
+    Discovery xblock metadata provider to be used in the tests.
+    """
+
+    def __init__(self, mock_xblocks=None):
+        """
+        Initialize with mocked courses.
+        """
+        super(DiscoveryXblockMetadataProvider, self).__init__()
+        self.mock_xblocks = mock_xblocks
+
+    def get_xblocks(self, xblock_ids):
+        if self.mock_xblocks is not None:
+            xblocks = self.mock_xblocks
+        else:
+            xblocks = [MockXblock(key=xblock_id) for xblock_id in xblock_ids]
+
+        return [{
+            'key': xblock.key,
+            'content_type': xblock.content_type,
+            'content': xblock.content,
+        } for xblock in xblocks]
+
+    def get_all_xblocks(self):
+        """
+        Get iterator of all the xblocks
+        """
+        if self.mock_xblocks is not None:
+            xblocks = self.mock_xblocks
+        else:
+            xblocks = [MockXblock() for _ in range(5)]
+        for xblock in xblocks:
+            yield {
+                'key': xblock.key,
+                'content_type': xblock.content_type,
+                'content': xblock.content,
             }

--- a/test_utils/providers.py
+++ b/test_utils/providers.py
@@ -3,7 +3,7 @@
 An implementation of providers to be used in tests.
 """
 
-from taxonomy.providers import CourseMetadataProvider, ProgramMetadataProvider, XBlockMetadataProvider
+from taxonomy.providers import CourseMetadataProvider, ProgramMetadataProvider, XBlockContent, XBlockMetadataProvider
 from test_utils.mocks import MockCourse, MockProgram, MockXBlock
 
 
@@ -111,11 +111,11 @@ class DiscoveryXBlockMetadataProvider(XBlockMetadataProvider):
         else:
             xblocks = [MockXBlock(key=xblock_id) for xblock_id in xblock_ids]
 
-        return [{
-            'key': xblock.key,
-            'content_type': xblock.content_type,
-            'content': xblock.content,
-        } for xblock in xblocks]
+        return [XBlockContent(
+            key=xblock.key,
+            content_type=xblock.content_type,
+            content=xblock.content,
+        ) for xblock in xblocks]
 
     def get_all_xblocks_in_course(self, course_id: str):
         """
@@ -126,8 +126,8 @@ class DiscoveryXBlockMetadataProvider(XBlockMetadataProvider):
         else:
             xblocks = [MockXBlock() for _ in range(5)]
         for xblock in xblocks:
-            yield {
-                'key': xblock.key,
-                'content_type': xblock.content_type,
-                'content': xblock.content,
-            }
+            yield XBlockContent(
+                key=xblock.key,
+                content_type=xblock.content_type,
+                content=xblock.content,
+            )

--- a/test_utils/providers.py
+++ b/test_utils/providers.py
@@ -117,9 +117,9 @@ class DiscoveryXBlockMetadataProvider(XBlockMetadataProvider):
             'content': xblock.content,
         } for xblock in xblocks]
 
-    def get_all_xblocks(self):
+    def get_all_xblocks_in_course(self, course_id: str):
         """
-        Get iterator of all the xblocks
+        Get iterator for all the unit/video xblocks in course.
         """
         if self.mock_xblocks is not None:
             xblocks = self.mock_xblocks

--- a/test_utils/providers.py
+++ b/test_utils/providers.py
@@ -3,8 +3,8 @@
 An implementation of providers to be used in tests.
 """
 
-from taxonomy.providers import CourseMetadataProvider, ProgramMetadataProvider, XblockMetadataProvider
-from test_utils.mocks import MockCourse, MockProgram, MockXblock
+from taxonomy.providers import CourseMetadataProvider, ProgramMetadataProvider, XBlockMetadataProvider
+from test_utils.mocks import MockCourse, MockProgram, MockXBlock
 
 
 class DiscoveryCourseMetadataProvider(CourseMetadataProvider):
@@ -93,7 +93,7 @@ class DiscoveryProgramMetadataProvider(ProgramMetadataProvider):
             }
 
 
-class DiscoveryXblockMetadataProvider(XblockMetadataProvider):
+class DiscoveryXBlockMetadataProvider(XBlockMetadataProvider):
     """
     Discovery xblock metadata provider to be used in the tests.
     """
@@ -102,14 +102,14 @@ class DiscoveryXblockMetadataProvider(XblockMetadataProvider):
         """
         Initialize with mocked courses.
         """
-        super(DiscoveryXblockMetadataProvider, self).__init__()
+        super(DiscoveryXBlockMetadataProvider, self).__init__()
         self.mock_xblocks = mock_xblocks
 
     def get_xblocks(self, xblock_ids):
         if self.mock_xblocks is not None:
             xblocks = self.mock_xblocks
         else:
-            xblocks = [MockXblock(key=xblock_id) for xblock_id in xblock_ids]
+            xblocks = [MockXBlock(key=xblock_id) for xblock_id in xblock_ids]
 
         return [{
             'key': xblock.key,
@@ -124,7 +124,7 @@ class DiscoveryXblockMetadataProvider(XblockMetadataProvider):
         if self.mock_xblocks is not None:
             xblocks = self.mock_xblocks
         else:
-            xblocks = [MockXblock() for _ in range(5)]
+            xblocks = [MockXBlock() for _ in range(5)]
         for xblock in xblocks:
             yield {
                 'key': xblock.key,

--- a/tests/management/test_refresh_course_skills.py
+++ b/tests/management/test_refresh_course_skills.py
@@ -15,7 +15,7 @@ from django.core.management import call_command
 
 from taxonomy.exceptions import CourseMetadataNotFoundError, InvalidCommandOptionsError, TaxonomyAPIError
 from taxonomy.models import CourseSkills, RefreshCourseSkillsConfig, Skill
-from test_utils.mocks import MockCourse
+from test_utils.mocks import MockCourse, mock_as_dict
 from test_utils.providers import DiscoveryCourseMetadataProvider
 from test_utils.sample_responses.skills import MISSING_NAME_SKILLS, SKILLS_EMSI_CLIENT_RESPONSE, TYPE_ERROR_SKILLS
 from test_utils.testcase import TaxonomyTestCase
@@ -33,9 +33,9 @@ class RefreshCourseSkillsCommandTests(TaxonomyTestCase):
         self.skills_emsi_client_response = SKILLS_EMSI_CLIENT_RESPONSE
         self.missing_skills = MISSING_NAME_SKILLS
         self.type_error_skills = TYPE_ERROR_SKILLS
-        self.course_1 = MockCourse()
-        self.course_2 = MockCourse()
-        self.course_3 = MockCourse()
+        self.course_1 = mock_as_dict(MockCourse())
+        self.course_2 = mock_as_dict(MockCourse())
+        self.course_3 = mock_as_dict(MockCourse())
         self.mock_access_token()
 
     def test_missing_arguments(self):
@@ -84,7 +84,6 @@ class RefreshCourseSkillsCommandTests(TaxonomyTestCase):
         self.course_1.title = ''
         self.course_1.short_description = ''
         self.course_1.full_description = ''
-        self.course_1.save()
         get_course_provider_mock.return_value = DiscoveryCourseMetadataProvider([self.course_1])
 
         skill = Skill.objects.all()

--- a/tests/management/test_refresh_program_skills.py
+++ b/tests/management/test_refresh_program_skills.py
@@ -15,7 +15,7 @@ from django.core.management import call_command
 
 from taxonomy.exceptions import ProgramMetadataNotFoundError, InvalidCommandOptionsError, TaxonomyAPIError
 from taxonomy.models import ProgramSkill, RefreshProgramSkillsConfig, Skill
-from test_utils.mocks import MockProgram
+from test_utils.mocks import MockProgram, mock_as_dict
 from test_utils.providers import DiscoveryProgramMetadataProvider
 from test_utils.sample_responses.skills import MISSING_NAME_SKILLS, SKILLS_EMSI_CLIENT_RESPONSE, TYPE_ERROR_SKILLS
 from test_utils.testcase import TaxonomyTestCase
@@ -33,9 +33,9 @@ class RefreshProgramSkillsCommandTests(TaxonomyTestCase):
         self.skills_emsi_client_response = SKILLS_EMSI_CLIENT_RESPONSE
         self.missing_skills = MISSING_NAME_SKILLS
         self.type_error_skills = TYPE_ERROR_SKILLS
-        self.program_1 = MockProgram()
-        self.program_2 = MockProgram()
-        self.program_3 = MockProgram()
+        self.program_1 = mock_as_dict(MockProgram())
+        self.program_2 = mock_as_dict(MockProgram())
+        self.program_3 = mock_as_dict(MockProgram())
         self.mock_access_token()
 
     def test_missing_arguments(self):
@@ -82,7 +82,6 @@ class RefreshProgramSkillsCommandTests(TaxonomyTestCase):
         Test that command work as expected if program overview does not exist.
         """
         self.program_1.overview = ''
-        self.program_1.save()
         get_program_provider_mock.return_value = DiscoveryProgramMetadataProvider([self.program_1])
 
         skill = Skill.objects.all()

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -52,7 +52,7 @@ class TaxonomyTasksTests(unittest.TestCase):
         Verify that `UPDATE_PROGRAM_SKILLS` signal work as expected.
         """
         get_product_skills_mock.return_value = self.skills_emsi_client_response
-        get_program_provider_mock.return_value = DiscoveryProgramMetadataProvider([self.course])
+        get_program_provider_mock.return_value = DiscoveryProgramMetadataProvider([self.program])
 
         # verify that no `Skill` and `ProgramSkill` records exist before executing the task
         skill = Skill.objects.all()

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -8,10 +8,14 @@ import mock
 from pytest import mark
 from testfixtures import LogCapture
 
-from taxonomy.models import CourseSkills, Skill, ProgramSkill
-from taxonomy.tasks import update_course_skills, update_program_skills
-from test_utils.mocks import MockCourse, MockProgram
-from test_utils.providers import DiscoveryCourseMetadataProvider, DiscoveryProgramMetadataProvider
+from taxonomy.models import CourseSkills, Skill, ProgramSkill, XblockSkills
+from taxonomy.tasks import update_course_skills, update_program_skills, update_xblock_skills
+from test_utils.mocks import MockCourse, MockProgram, MockXblock
+from test_utils.providers import (
+    DiscoveryCourseMetadataProvider,
+    DiscoveryProgramMetadataProvider,
+    DiscoveryXblockMetadataProvider,
+)
 from test_utils.sample_responses.skills import SKILLS_EMSI_CLIENT_RESPONSE
 
 
@@ -25,6 +29,7 @@ class TaxonomyTasksTests(unittest.TestCase):
         self.skills_emsi_client_response = SKILLS_EMSI_CLIENT_RESPONSE
         self.course = MockCourse()
         self.program = MockProgram()
+        self.xblock = MockXblock()
         super().setUp()
 
     def check_empty_skill_models(self, product_skill_model):
@@ -122,3 +127,46 @@ class TaxonomyTasksTests(unittest.TestCase):
 
         self.assertEqual(skill.count(), 0)
         self.assertEqual(program_skill.count(), 0)
+
+    @mock.patch('taxonomy.tasks.get_xblock_metadata_provider')
+    @mock.patch('taxonomy.tasks.utils.EMSISkillsApiClient.get_product_skills')
+    def test_update_xblock_skills_task(self, get_xblock_skills_mock, get_xblock_provider_mock):
+        """
+        Verify that `update_xblock_skills` task work as expected.
+        """
+        get_xblock_skills_mock.return_value = self.skills_emsi_client_response
+        get_xblock_provider_mock.return_value = DiscoveryXblockMetadataProvider([self.xblock])
+
+        skill, xblock_skill = self.check_empty_skill_models(XblockSkills)
+
+        update_xblock_skills.delay([self.xblock.key])
+
+        self.assertEqual(skill.count(), 4)
+        self.assertEqual(xblock_skill.count(), 1)
+        self.assertEqual(xblock_skill.first().skills.count(), 4)
+
+    @mock.patch('taxonomy.tasks.get_xblock_metadata_provider')
+    @mock.patch('taxonomy.tasks.utils.EMSISkillsApiClient.get_product_skills')
+    def test_update_xblock_skills_task_with_no_xblock_found(self, get_course_skills_mock, get_course_provider_mock):
+        """
+        Verify that `update_skills` task work as expected.
+        """
+        get_course_skills_mock.return_value = self.skills_emsi_client_response
+        get_course_provider_mock.return_value = DiscoveryXblockMetadataProvider([])
+
+        skill, xblock_skill = self.check_empty_skill_models(XblockSkills)
+
+        with LogCapture(level=logging.INFO) as log_capture:
+            update_xblock_skills.delay([self.xblock.key])
+            messages = [record.msg for record in log_capture.records]
+            self.assertEqual(
+                messages,
+                [
+                    '[TAXONOMY] refresh_xblock_skills task triggered',
+                    '[TAXONOMY] No xblock found with uuids [%d] to update skills.',
+                    'Task %(name)s[%(id)s] succeeded in %(runtime)ss: %(return_value)s'
+                ]
+            )
+
+        self.assertEqual(skill.count(), 0)
+        self.assertEqual(xblock_skill.count(), 0)

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -8,13 +8,13 @@ import mock
 from pytest import mark
 from testfixtures import LogCapture
 
-from taxonomy.models import CourseSkills, Skill, ProgramSkill, XblockSkills
+from taxonomy.models import CourseSkills, Skill, ProgramSkill, XBlockSkills
 from taxonomy.tasks import update_course_skills, update_program_skills, update_xblock_skills
-from test_utils.mocks import MockCourse, MockProgram, MockXblock
+from test_utils.mocks import MockCourse, MockProgram, MockXBlock
 from test_utils.providers import (
     DiscoveryCourseMetadataProvider,
     DiscoveryProgramMetadataProvider,
-    DiscoveryXblockMetadataProvider,
+    DiscoveryXBlockMetadataProvider,
 )
 from test_utils.sample_responses.skills import SKILLS_EMSI_CLIENT_RESPONSE
 
@@ -29,7 +29,7 @@ class TaxonomyTasksTests(unittest.TestCase):
         self.skills_emsi_client_response = SKILLS_EMSI_CLIENT_RESPONSE
         self.course = MockCourse()
         self.program = MockProgram()
-        self.xblock = MockXblock()
+        self.xblock = MockXBlock()
         super().setUp()
 
     def check_empty_skill_models(self, product_skill_model):
@@ -135,9 +135,9 @@ class TaxonomyTasksTests(unittest.TestCase):
         Verify that `update_xblock_skills` task work as expected.
         """
         get_xblock_skills_mock.return_value = self.skills_emsi_client_response
-        get_xblock_provider_mock.return_value = DiscoveryXblockMetadataProvider([self.xblock])
+        get_xblock_provider_mock.return_value = DiscoveryXBlockMetadataProvider([self.xblock])
 
-        skill, xblock_skill = self.check_empty_skill_models(XblockSkills)
+        skill, xblock_skill = self.check_empty_skill_models(XBlockSkills)
 
         update_xblock_skills.delay([self.xblock.key])
 
@@ -152,9 +152,9 @@ class TaxonomyTasksTests(unittest.TestCase):
         Verify that `update_skills` task work as expected.
         """
         get_course_skills_mock.return_value = self.skills_emsi_client_response
-        get_course_provider_mock.return_value = DiscoveryXblockMetadataProvider([])
+        get_course_provider_mock.return_value = DiscoveryXBlockMetadataProvider([])
 
-        skill, xblock_skill = self.check_empty_skill_models(XblockSkills)
+        skill, xblock_skill = self.check_empty_skill_models(XBlockSkills)
 
         with LogCapture(level=logging.INFO) as log_capture:
             update_xblock_skills.delay([self.xblock.key])

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -273,7 +273,7 @@ class TestUtils(TaxonomyTestCase):
         assert utils.is_skill_blacklisted(
             xblock.id,
             black_listed_xblock_skill.skill.id,
-            ProductTypes.XBlockThrough,
+            ProductTypes.XBlockData,
         ) is True
         xblock_skill = models.XBlockSkillData.objects.get(
             xblock=xblock,
@@ -282,7 +282,7 @@ class TestUtils(TaxonomyTestCase):
         assert xblock_skill.is_blacklisted is True
 
         # Make sure that skill that was not black listed is added with no issues.
-        assert utils.is_skill_blacklisted(xblock.id, self.skill.id, ProductTypes.XBlockThrough) is False
+        assert utils.is_skill_blacklisted(xblock.id, self.skill.id, ProductTypes.XBlockData) is False
         assert models.XBlockSkillData.objects.filter(
             xblock=xblock,
             skill=self.skill,

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -220,10 +220,10 @@ class TestUtils(TaxonomyTestCase):
         """
         Validate that update_xblock_skills_data works as expected.
         """
-        xblock = factories.XblockSkillsFactory(usage_key=USAGE_KEY)
-        black_listed_xblock_skill = factories.XblockSkillThroughFactory(xblock=xblock, is_blacklisted=True)
+        xblock = factories.XBlockSkillsFactory(usage_key=USAGE_KEY)
+        black_listed_xblock_skill = factories.XBlockSkillThroughFactory(xblock=xblock, is_blacklisted=True)
         skills_count = Skill.objects.count()
-        product_type = ProductTypes.Xblock
+        product_type = ProductTypes.XBlock
         utils.update_skills_data(
             key_or_uuid=USAGE_KEY,
             skill_external_id=black_listed_xblock_skill.skill.external_id,
@@ -261,21 +261,21 @@ class TestUtils(TaxonomyTestCase):
         # make sure no new `Skill` object created.
         assert Skill.objects.count() == skills_count
 
-        # Make sure `XblockSkills` is not removed from the blacklist.
+        # Make sure `XBlockSkills` is not removed from the blacklist.
         assert utils.is_skill_blacklisted(
             xblock.id,
             black_listed_xblock_skill.skill.id,
-            ProductTypes.XblockThrough,
+            ProductTypes.XBlockThrough,
         ) is True
-        xblock_skill = models.XblockSkillThrough.objects.get(
+        xblock_skill = models.XBlockSkillThrough.objects.get(
             xblock=xblock,
             skill=black_listed_xblock_skill.skill,
         )
         assert xblock_skill.is_blacklisted is True
 
         # Make sure that skill that was not black listed is added with no issues.
-        assert utils.is_skill_blacklisted(xblock.id, self.skill.id, ProductTypes.XblockThrough) is False
-        assert models.XblockSkillThrough.objects.filter(
+        assert utils.is_skill_blacklisted(xblock.id, self.skill.id, ProductTypes.XBlockThrough) is False
+        assert models.XBlockSkillThrough.objects.filter(
             xblock=xblock,
             skill=self.skill,
             is_blacklisted=False,

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -769,13 +769,14 @@ class TestUtils(TaxonomyTestCase):
         assert translation_record.translated_text == new_course_description
         assert translate_mocked.call_count == 3
 
-    def test_process_skill_attr(self):
+    def test_process_skill_attr_text(self):
         """
-        validate process_skill_attr returns correct data and flag
+        validate process_skill_attr_text and skip_product_processing returns correct data and flag
         """
         text = "some text"
         xblock = factories.XBlockSkillsFactory(usage_key=USAGE_KEY)
-        extra_data, skip = utils.process_skill_attr(text, USAGE_KEY, ProductTypes.XBlock)
+        extra_data = utils.process_skill_attr_text(text, ProductTypes.XBlock)
+        skip = utils.skip_product_processing(extra_data, USAGE_KEY, ProductTypes.XBlock)
         # xblock with new text should not skip.
         assert not skip
         assert "hash_content" in extra_data
@@ -784,7 +785,8 @@ class TestUtils(TaxonomyTestCase):
         xblock.save()
 
         # xblock with same content should skip processing.
-        extra_data, skip = utils.process_skill_attr(text, USAGE_KEY, ProductTypes.XBlock)
+        extra_data = utils.process_skill_attr_text(text, ProductTypes.XBlock)
+        skip = utils.skip_product_processing(extra_data, USAGE_KEY, ProductTypes.XBlock)
         assert skip
 
     @mock.patch('taxonomy.utils.EMSISkillsApiClient.get_product_skills')

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -16,7 +16,7 @@ from taxonomy.constants import ENGLISH
 from taxonomy.exceptions import TaxonomyAPIError
 from taxonomy.models import CourseSkills, JobSkills, Skill, Translation
 from test_utils import factories
-from test_utils.constants import COURSE_KEY, PROGRAM_UUID
+from test_utils.constants import COURSE_KEY, PROGRAM_UUID, USAGE_KEY
 from test_utils.mocks import MockCourse, MockProgram
 from test_utils.sample_responses.skills import SKILLS_EMSI_CLIENT_RESPONSE
 from test_utils.testcase import TaxonomyTestCase
@@ -204,6 +204,79 @@ class TestUtils(TaxonomyTestCase):
         assert utils.is_skill_blacklisted(PROGRAM_UUID, self.skill.id, product_type) is False
         assert models.ProgramSkill.objects.filter(
             program_uuid=PROGRAM_UUID,
+            skill=self.skill,
+            is_blacklisted=False,
+        ).exists()
+
+        # Make sure the `Skill` object updated
+        self.skill.refresh_from_db()
+        assert self.skill.name == skill_data.get('name')
+        assert self.skill.info_url == skill_data.get('info_url')
+        assert self.skill.type_id == skill_data.get('type_id')
+        assert self.skill.type_name == skill_data.get('type_name')
+        assert self.skill.description == skill_data.get('description')
+
+    def test_update_xblock_skills_data(self):
+        """
+        Validate that update_xblock_skills_data works as expected.
+        """
+        xblock = factories.XblockSkillsFactory(usage_key=USAGE_KEY)
+        black_listed_xblock_skill = factories.XblockSkillThroughFactory(xblock=xblock, is_blacklisted=True)
+        skills_count = Skill.objects.count()
+        product_type = ProductTypes.Xblock
+        utils.update_skills_data(
+            key_or_uuid=USAGE_KEY,
+            skill_external_id=black_listed_xblock_skill.skill.external_id,
+            confidence=black_listed_xblock_skill.confidence,
+            skill_data={
+                'name': black_listed_xblock_skill.skill.name,
+                'info_url': black_listed_xblock_skill.skill.info_url,
+                'type_id': black_listed_xblock_skill.skill.type_id,
+                'type_name': black_listed_xblock_skill.skill.type_name,
+                'description': black_listed_xblock_skill.skill.description
+            },
+            product_type=product_type
+        )
+
+        updated_name = 'new_name'
+        updated_info_url = 'new_url'
+        updated_type_id = '1'
+        updated_type_name = 'new_type'
+        updated_description = 'new description'
+        skill_data = {
+            'name': updated_name,
+            'info_url': updated_info_url,
+            'type_id': updated_type_id,
+            'type_name': updated_type_name,
+            'description': updated_description
+        }
+        utils.update_skills_data(
+            key_or_uuid=USAGE_KEY,
+            skill_external_id=self.skill.external_id,
+            confidence=0.9,
+            skill_data=skill_data,
+            product_type=product_type
+        )
+
+        # make sure no new `Skill` object created.
+        assert Skill.objects.count() == skills_count
+
+        # Make sure `XblockSkills` is not removed from the blacklist.
+        assert utils.is_skill_blacklisted(
+            xblock.id,
+            black_listed_xblock_skill.skill.id,
+            ProductTypes.XblockThrough,
+        ) is True
+        xblock_skill = models.XblockSkillThrough.objects.get(
+            xblock=xblock,
+            skill=black_listed_xblock_skill.skill,
+        )
+        assert xblock_skill.is_blacklisted is True
+
+        # Make sure that skill that was not black listed is added with no issues.
+        assert utils.is_skill_blacklisted(xblock.id, self.skill.id, ProductTypes.XblockThrough) is False
+        assert models.XblockSkillThrough.objects.filter(
+            xblock=xblock,
             skill=self.skill,
             is_blacklisted=False,
         ).exists()

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -260,10 +260,10 @@ class TestUtils(TaxonomyTestCase):
             hash_content=hash_content,
         )
 
-        # make sure no new `Skill` object created.
+        # Make sure no new `Skill` object is created.
         assert Skill.objects.count() == skills_count
 
-        # make sure hash_content is stored properly
+        # Make sure hash_content is stored properly.
         assert XBlockSkills.objects.filter(
             usage_key=USAGE_KEY,
             hash_content=hash_content,
@@ -279,17 +279,17 @@ class TestUtils(TaxonomyTestCase):
             xblock=xblock,
             skill=black_listed_xblock_skill.skill,
         )
-        assert xblock_skill.is_blacklisted is True
+        assert xblock_skill.is_blacklisted
 
-        # Make sure that skill that was not black listed is added with no issues.
-        assert utils.is_skill_blacklisted(xblock.id, self.skill.id, ProductTypes.XBlockData) is False
+        # Make sure the skill that was not black listed is added with no issues.
+        assert not utils.is_skill_blacklisted(xblock.id, self.skill.id, ProductTypes.XBlockData)
         assert models.XBlockSkillData.objects.filter(
             xblock=xblock,
             skill=self.skill,
             is_blacklisted=False,
         ).exists()
 
-        # Make sure the `Skill` object updated
+        # Make sure the `Skill` object is updated
         self.skill.refresh_from_db()
         assert self.skill.name == skill_data.get('name')
         assert self.skill.info_url == skill_data.get('info_url')
@@ -771,13 +771,13 @@ class TestUtils(TaxonomyTestCase):
 
     def test_process_skill_attr_text(self):
         """
-        validate process_skill_attr_text and skip_product_processing returns correct data and flag
+        Validate process_skill_attr_text and skip_product_processing returns correct data and flag.
         """
         text = "some text"
         xblock = factories.XBlockSkillsFactory(usage_key=USAGE_KEY)
         extra_data = utils.process_skill_attr_text(text, ProductTypes.XBlock)
         skip = utils.skip_product_processing(extra_data, USAGE_KEY, ProductTypes.XBlock)
-        # xblock with new text should not skip.
+        # XBlock with new text should not skip.
         assert not skip
         assert "hash_content" in extra_data
         xblock.hash_content = extra_data["hash_content"]

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -221,7 +221,7 @@ class TestUtils(TaxonomyTestCase):
         Validate that update_xblock_skills_data works as expected.
         """
         xblock = factories.XBlockSkillsFactory(usage_key=USAGE_KEY)
-        black_listed_xblock_skill = factories.XBlockSkillThroughFactory(xblock=xblock, is_blacklisted=True)
+        black_listed_xblock_skill = factories.XBlockSkillDataFactory(xblock=xblock, is_blacklisted=True)
         skills_count = Skill.objects.count()
         product_type = ProductTypes.XBlock
         utils.update_skills_data(
@@ -275,7 +275,7 @@ class TestUtils(TaxonomyTestCase):
             black_listed_xblock_skill.skill.id,
             ProductTypes.XBlockThrough,
         ) is True
-        xblock_skill = models.XBlockSkillThrough.objects.get(
+        xblock_skill = models.XBlockSkillData.objects.get(
             xblock=xblock,
             skill=black_listed_xblock_skill.skill,
         )
@@ -283,7 +283,7 @@ class TestUtils(TaxonomyTestCase):
 
         # Make sure that skill that was not black listed is added with no issues.
         assert utils.is_skill_blacklisted(xblock.id, self.skill.id, ProductTypes.XBlockThrough) is False
-        assert models.XBlockSkillThrough.objects.filter(
+        assert models.XBlockSkillData.objects.filter(
             xblock=xblock,
             skill=self.skill,
             is_blacklisted=False,

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -4,8 +4,12 @@ Test that there are no errors in validators logic.
 These tests are here to validate that errors will not appear while running
 validation logic inside host platform.
 """
-from taxonomy.validators import CourseMetadataProviderValidator, ProgramMetadataProviderValidator
-from test_utils.mocks import MockCourse, MockProgram
+from taxonomy.validators import (
+    CourseMetadataProviderValidator,
+    ProgramMetadataProviderValidator,
+    XblockMetadataProviderValidator,
+)
+from test_utils.mocks import MockCourse, MockProgram, MockXblock
 from test_utils.testcase import TaxonomyTestCase
 
 
@@ -53,3 +57,26 @@ class TestProgramMetadataProviderValidator(TaxonomyTestCase):
         Validate that code runs without any errors.
         """
         self.program_metadata_validator.validate()
+
+
+class TestXblockMetadataProviderValidator(TaxonomyTestCase):
+    """
+    Validate that validation logic does not have any errors.
+    """
+
+    def setUp(self):
+        """
+        Instantiate an instance of XblockMetadataProviderValidator for use inside tests.
+        """
+        super(TestXblockMetadataProviderValidator, self).setUp()
+        self.xblock = MockXblock()
+
+        self.xblock_metadata_validator = XblockMetadataProviderValidator(
+            [str(self.xblock.key)]
+        )
+
+    def test_validate(self):
+        """
+        Validate that code runs without any errors.
+        """
+        self.xblock_metadata_validator.validate()

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -7,9 +7,9 @@ validation logic inside host platform.
 from taxonomy.validators import (
     CourseMetadataProviderValidator,
     ProgramMetadataProviderValidator,
-    XblockMetadataProviderValidator,
+    XBlockMetadataProviderValidator,
 )
-from test_utils.mocks import MockCourse, MockProgram, MockXblock
+from test_utils.mocks import MockCourse, MockProgram, MockXBlock
 from test_utils.testcase import TaxonomyTestCase
 
 
@@ -59,19 +59,19 @@ class TestProgramMetadataProviderValidator(TaxonomyTestCase):
         self.program_metadata_validator.validate()
 
 
-class TestXblockMetadataProviderValidator(TaxonomyTestCase):
+class TestXBlockMetadataProviderValidator(TaxonomyTestCase):
     """
     Validate that validation logic does not have any errors.
     """
 
     def setUp(self):
         """
-        Instantiate an instance of XblockMetadataProviderValidator for use inside tests.
+        Instantiate an instance of XBlockMetadataProviderValidator for use inside tests.
         """
-        super(TestXblockMetadataProviderValidator, self).setUp()
-        self.xblock = MockXblock()
+        super(TestXBlockMetadataProviderValidator, self).setUp()
+        self.xblock = MockXBlock()
 
-        self.xblock_metadata_validator = XblockMetadataProviderValidator(
+        self.xblock_metadata_validator = XBlockMetadataProviderValidator(
             [str(self.xblock.key)]
         )
 


### PR DESCRIPTION
Creates celery task similar to [update_course_skills](https://github.com/openedx/taxonomy-connector/blob/287bfddb2a9777198794bc820a6325e39babb81d/taxonomy/tasks.py#L17-L30) in taxonomy-connector to update_xblock_skills.

Also implements an abstract provider similar to [course provider](https://github.com/openedx/taxonomy-connector/blob/287bfddb2a9777198794bc820a6325e39babb81d/taxonomy/providers/course_metadata.py#L10).

Makes appropriate changes to [refresh_product_skills](https://github.com/openedx/taxonomy-connector/blob/287bfddb2a9777198794bc820a6325e39babb81d/taxonomy/utils.py#L162) to handle xblocks skill tagging.

**Reviewers**

- [ ] @farhaanbukhsh
- [ ] @bradenmacdonald 

**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
- [ ] [Version](https://github.com/edx/taxonomy-connector/blob/master/taxonomy/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/taxonomy-connector/blob/master/CHANGELOG.rst) record added

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/taxonomy-connector/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/taxonomy-connector/actions), verify version has been pushed to [PyPI](https://pypi.org/project/taxonomy-connector/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [course-discovery](https://github.com/edx/course-discovery) to upgrade dependencies (including taxonomy-connector)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in course-discovery will look for the latest version in PyPi.